### PR TITLE
abc150 D を解いた

### DIFF
--- a/abc150/D.rb
+++ b/abc150/D.rb
@@ -5,7 +5,17 @@
 N, M = gets.split.map(&:to_i)
 as = gets.split.map(&:to_i)
 
-lcm = as.inject(1) { |result, ai| result.lcm(ai/2) }
+require 'prime'
+index_of_2 = Prime.prime_division(as.first).first[1]
+
+lcm = as.inject(1) do |result, ai|
+  if (ai / (2 ** index_of_2)).even?
+    puts 0
+    exit
+  end
+  result.lcm(ai/2)
+end
+
 lcm_x_count = M / lcm
 
 puts lcm_x_count / 2 + lcm_x_count % 2


### PR DESCRIPTION
Xは、与えられた配列のすべて要素に対して
X = (`要素 ÷ 2`) × `奇数`
を満たせば良い。ただしXは `1..M`。

すべての要素について `要素 ÷ 2` の最小公倍数を求める。
基本的にはその `最小公倍数` × `奇数` を満たす `1..M` の整数の個数を求めればOK。

ここまではコンテスト中に解けた。

ただし、与えられた要素によっては、条件を満たす整数が存在しないケースがある。
その考慮が抜けていた。